### PR TITLE
Update drizzle.config.ts schema path

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -2,6 +2,6 @@ import type { Config } from "drizzle-kit";
 
 export default {
   out: "./drizzle",
-  schema: "./app/database/schema.ts",
+  schema: "./app/lib/database/schema.ts",
   dialect: "sqlite",
 } satisfies Config;


### PR DESCRIPTION
previous path was causing the following error after exe the db:generate script.

No schema files found for path config ['./app/database/schema.ts']